### PR TITLE
Adds configurable ability to redirect HTTP to HTTPS

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -3,6 +3,9 @@ LOG_LEVEL=DEBUG
 DATABASE_URL=postgres://fider:fider_pw@localhost:5555/fider?sslmode=disable
 JWT_SECRET=hsjl]W;&ZcHxT&FK;s%bgIQF:#ch=~#Al4:5]N;7V<qPZ3e9lT4'%;go;LIkc%k
 
+HOST_DOMAIN=localhost
+FORCE_SSL=false
+
 CDN_HOST=localhost:3000
 
 # MAINTENANCE=true

--- a/app/middlewares/tenant.go
+++ b/app/middlewares/tenant.go
@@ -35,6 +35,10 @@ func SingleTenant() web.MiddlewareFunc {
 				c.SetTenant(firstTenant.Result)
 			}
 
+			if env.Config.ForceSSL && env.Config.HostDomain != "" && c.Request.URL.Scheme != "https" {
+				return c.Redirect("https://" + env.Config.HostDomain + c.Request.URL.Path + "?" + c.Request.URL.RawQuery)
+			}
+
 			return next(c)
 		}
 	}

--- a/app/pkg/env/env.go
+++ b/app/pkg/env/env.go
@@ -14,16 +14,17 @@ import (
 )
 
 type config struct {
-	Environment 	 string `env:"GO_ENV,default=production"`
+	Environment    string `env:"GO_ENV,default=production"`
 	SignUpDisabled bool   `env:"SIGNUP_DISABLED,default=false"`
-	AutoSSL     	 bool   `env:"SSL_AUTO,default=false"`
-	SSLCert     	 string `env:"SSL_CERT"`
-	SSLCertKey  	 string `env:"SSL_CERT_KEY"`
-	Port        	 string `env:"PORT,default=3000"`
-	HostMode    	 string `env:"HOST_MODE,default=single"`
-	HostDomain  	 string `env:"HOST_DOMAIN"`
-	JWTSecret   	 string `env:"JWT_SECRET,required"`
-	Rendergun   	 struct {
+	AutoSSL        bool   `env:"SSL_AUTO,default=false"`
+	SSLCert        string `env:"SSL_CERT"`
+	SSLCertKey     string `env:"SSL_CERT_KEY"`
+	ForceSSL       bool   `env:"FORCE_SSL,default=true"`
+	Port           string `env:"PORT,default=3000"`
+	HostMode       string `env:"HOST_MODE,default=single"`
+	HostDomain     string `env:"HOST_DOMAIN"`
+	JWTSecret      string `env:"JWT_SECRET,required"`
+	Rendergun      struct {
 		URL string `env:"RENDERGUN_URL"`
 	}
 	Database struct {


### PR DESCRIPTION
Adds the option FORCE_SSL to environment variables. Boolean. Defaults to true.

Couple with the existing HOST_DOMAIN environment variable to enable  HTTP to HTTPS redirection. Domain setting required out of paranoia against accidentally creating an open proxy. SSL redirection will not happen unless HOST_DOMAIN is set, regardless of the FORCE_SSL setting.

IOW if you just set a HOST_DOMAIN env var now (to, say, "www.example.com"), it should redirect all HTTP requests to HTTPS at that domain. If you set HOST_DOMAIN but set FORCE_SSL to false, it will not redirect. If HOST_DOMAIN is not set it won't redirect in any case.